### PR TITLE
Supports GHC 8.8

### DIFF
--- a/src/Data/Deserializer.hs
+++ b/src/Data/Deserializer.hs
@@ -100,7 +100,7 @@ import Control.Monad (unless)
 import Control.Monad.Fail (MonadFail (fail))
 
 -- | Deserialization monad.
-class (Monad μ, MonadFail μ, Parsing μ) ⇒ Deserializer μ where
+class (MonadFail μ, Parsing μ) ⇒ Deserializer μ where
   {-# MINIMAL ensure, take, chunk, isolate #-}
   -- | Default byte order of the deserializer.
   endian ∷ Proxy μ → Endian

--- a/src/Data/Serializer.hs
+++ b/src/Data/Serializer.hs
@@ -64,8 +64,10 @@ import GHC.Generics (Generic)
 import Data.Typeable (Typeable)
 import Data.Data (Data)
 import Data.Proxy (Proxy(..))
+#if !MIN_VERSION_base(4, 13, 0)
 import Data.Semigroup (Semigroup, (<>))
 import Data.Monoid (Monoid)
+#endif
 import Data.Endian (Endian(..), swapEndian)
 import Data.Word
 import Data.Int


### PR DESCRIPTION
`fail` is removed from `Monad` since base of GHC 8.8.

I have tested with GHC 8.4, 8.6, 8.8.