### PR TITLE
Eta-expand for simplified subsumption to compile with GHC 9.

### DIFF
--- a/src/Data/Deserializer.hs
+++ b/src/Data/Deserializer.hs
@@ -637,16 +637,16 @@ instance Deserializer μ ⇒ Deserializer (BigEndianDeserializer μ) where
 -- | Force the default byte order.
 deserializeIn ∷ Deserializer μ
               ⇒ Endian → (∀ μ' . (Deserializer μ') ⇒ μ' α) → μ α
-deserializeIn LittleEndian = deserializeL
-deserializeIn BigEndian    = deserializeB
+deserializeIn LittleEndian d = deserializeL d
+deserializeIn BigEndian    d = deserializeB d
 {-# INLINE deserializeIn #-}
 
 -- | Force the default byte order to be the host byte order.
 deserializeH ∷ Deserializer μ ⇒ (∀ μ' . (Deserializer μ') ⇒ μ' α) → μ α
 #ifdef WORDS_BIGENDIAN
-deserializeH = deserializeB
+deserializeH d = deserializeB d
 #else
-deserializeH = deserializeL
+deserializeH d = deserializeL d
 #endif
 
 -- | Deserialization result.

--- a/src/Data/Serializer.hs
+++ b/src/Data/Serializer.hs
@@ -578,16 +578,16 @@ instance Serializer s ⇒ Serializer (BigEndianSerializer s) where
 
 -- | Force the default byte order.
 serializeIn ∷ Serializer s ⇒ Endian → (∀ s' . (Serializer s') ⇒ s') → s
-serializeIn LittleEndian = serializeL
-serializeIn BigEndian    = serializeB
+serializeIn LittleEndian e = serializeL e
+serializeIn BigEndian    e = serializeB e
 {-# INLINE serializeIn #-}
 
 -- | Force the default byte order to be the host byte order.
 serializeH ∷ Serializer s ⇒ (∀ s' . (Serializer s') ⇒ s') → s
 #ifdef WORDS_BIGENDIAN
-serializeH = serializeB
+serializeH e = serializeB e
 #else
-serializeH = serializeL
+serializeH e = serializeL e
 #endif
 {-# INLINE serializeH #-}
 


### PR DESCRIPTION
Because of the new simplified subsumption (https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst), this package doesn't build under the recent pre-release of GHC 9.  However, this can be easily solved by eta-expanding a handful of definitions.

Also, I noticed that `deserializeH` is not marked as `INLINE`.  Is this intentional?